### PR TITLE
Framed mode

### DIFF
--- a/applications/prisme/src/app/components/form/formly/framed/framed.example.ts
+++ b/applications/prisme/src/app/components/form/formly/framed/framed.example.ts
@@ -21,7 +21,7 @@ export class FramedExample {
 						{
 							type: 'input',
 							key: 'lastName',
-							className: 'form-group-line-md6',
+							className: 'form-group-line-col mod-md6',
 
 							templateOptions: {
 								label: 'Nom',
@@ -31,7 +31,7 @@ export class FramedExample {
 						{
 							type: 'input',
 							key: 'firstName',
-							className: 'form-group-line-md6',
+							className: 'form-group-line-col mod-md6',
 							templateOptions: {
 								label: 'Prenom',
 							}

--- a/applications/prisme/src/app/components/form/framed/basic/basic.example.html
+++ b/applications/prisme/src/app/components/form/framed/basic/basic.example.html
@@ -1,157 +1,177 @@
 <div class="form mod-framed">
-	<div class="form-group">
-		<h2>Titre Groupe 1</h2>
+	<fieldset class="form-group">
+		<legend class="form-group-legend">Titre Groupe 1</legend>
 		<div class="form-group-line">
-			<div class="form-group-line-lg8">
+			<div class="form-group-line-col">
 				<label class="textfield is-required">
-					<input class="textfield-input is-error" type="text" placeholder="placeholder">
+					<input class="textfield-input is-error" type="text" placeholder="placeholder" aria-required="required" />
 					<span class="textfield-label">Label textfield</span>
 				</label>
 			</div>
-			<div class="form-group-line-lg4">
+			<div class="form-group-line-col mod-lg4">
 				<label class="textfield">
-					<input class="textfield-input" type="text" placeholder="placeholder" value="Test disabled" disabled>
+					<input class="textfield-input" type="text" placeholder="placeholder" value="Test disabled" disabled="disabled" />
 					<span class="textfield-label">Label textfield</span>
 				</label>
 			</div>
 		</div>
 		<div class="form-group-line">
-			<label class="textfield palette-success">
-				<input class="textfield-input" type="text" placeholder="placeholder">
-				<span class="textfield-label">Label textfield</span>
-			</label>
-		</div>
-		<div class="form-group-line">
-			<label class="textfield mod-withSuffix">
-				<input class="textfield-input" type="text" placeholder="Money Money">
-				<span class="textfield-label">Label textfield</span>
-				<span class="textfield-suffix">
-					€
-				</span>
-			</label>
-		</div>
-		<div class="form-group-line">
-			<label class="textfield mod-multiline mod-withSuffix">
-				<textarea class="textfield-input" type="text" placeholder="Money Money"></textarea>
-				<span class="textfield-label">Label textfield</span>
-				<span class="textfield-suffix">
-					€
-					<!-- 
-					<select>
-						<option>Option 1</option>
-					</select>
-					-->
-				</span>
-			</label>
-		</div>
-	</div>
-	<div class="form-group">
-		<h2>Titre groupe 2</h2>
-		<div class="form-group-line">
-			<label class="textfield mod-multiline mod-withSuffix palette-secondary is-required">
-				<textarea class="textfield-input" type="text" placeholder="Money Money"></textarea>
-				<span class="textfield-label">Label textfield</span>
-				<span class="textfield-suffix">
-					€
-					<!--
-					<select>
-						<option>Option 1</option>
-					</select>
-					-->
-				</span>
-			</label>
-		</div>
-		<div class="form-group-line">
-			<label id="autocomplete-framed" class="textfield mod-search">
-				<input class="textfield-input" type="text">
-				<span class="textfield-label">Utilisateur</span>
-				<ul class="textfield-options">
-					<li class="textfield-options-entry">
-						<u>va</u>lue A</li>
-					<li class="textfield-options-entry is-focus">
-						<u>va</u>lue B</li>
-					<li class="textfield-options-entry">
-						<u>va</u>lue C</li>
-				</ul>
-			</label>
-		</div>
-		<div class="form-group-line">
-			<label id="autocomplete-framed-select" class="textfield mod-select">
-				<input class="textfield-input" type="text">
-				<span class="textfield-label">Utilisateur</span>
-				<ul class="textfield-options">
-					<li class="textfield-options-entry">
-						<u>va</u>lue A</li>
-					<li class="textfield-options-entry is-focus">
-						<u>va</u>lue B</li>
-					<li class="textfield-options-entry">
-						<u>va</u>lue C</li>
-				</ul>
-			</label>
-		</div>
-		<div class="form-group-line">
-			<div class="form-group-line-xs6">
-				<label id="autocomplete-framed-select2" class="textfield mod-select">
-					<input class="textfield-input" type="text">
-					<span class="textfield-label">Utilisateur</span>
-					<ul class="textfield-options">
-						<li class="textfield-options-entry">
-							<u>va</u>lue A</li>
-						<li class="textfield-options-entry is-focus">
-							<u>va</u>lue B</li>
-						<li class="textfield-options-entry">
-							<u>va</u>lue C</li>
-					</ul>
+			<div class="form-group-line-col">
+				<label class="textfield palette-success">
+					<input class="textfield-input" type="text" placeholder="placeholder" />
+					<span class="textfield-label">Label textfield</span>
 				</label>
 			</div>
-			<div class="form-group-line-xs6">
-				<label class="textfield is-required">
-					<input class="textfield-input is-error" type="text" placeholder="placeholder">
+		</div>
+		<div class="form-group-line">
+			<div class="form-group-line-col">
+				<label class="textfield mod-withSuffix">
+					<input class="textfield-input" type="text" placeholder="Money Money" />
 					<span class="textfield-label">Label textfield</span>
-					<span class="textfield-messages">
-						<span class="textfield-messages-error" style="display: block">Ce champs est requis</span>
+					<span class="textfield-suffix">
+						€
 					</span>
 				</label>
 			</div>
 		</div>
 		<div class="form-group-line">
-			<label class="checkbox mod-field">
-				<input class="checkbox-input" type="checkbox">
-				<span class="checkbox-label">Checkbox</span>
-			</label>
+			<div class="form-group-line-col mod-overlay-top">
+				<label class="textfield mod-multiline mod-withSuffix">
+					<textarea class="textfield-input" type="text" placeholder="Money Money"></textarea>
+					<span class="textfield-label">Label textfield</span>
+					<span class="textfield-suffix">
+						€
+					</span>
+				</label>
+				<label class="select">
+					<select>
+						<option>Option 1</option>
+					</select>
+					<span class="select-label u-mask">Select label</span>
+				</label>
+			</div>
+		</div>
+	</fieldset>
+	<fieldset class="form-group">
+		<legend class="form-group-legend">Titre Groupe 2</legend>
+		<div class="form-group-line">
+			<div class="form-group-line-col mod-overlay-top">
+				<label class="textfield mod-multiline mod-withSuffix palette-secondary is-required">
+					<textarea class="textfield-input" type="text" placeholder="Money Money"></textarea>
+					<span class="textfield-label">Label textfield</span>
+					<span class="textfield-suffix">
+						€
+					</span>
+				</label>
+				<label class="select">
+					<select>
+						<option>Option 1</option>
+					</select>
+					<span class="select-label u-mask">Select label</span>
+				</label>
+			</div>
 		</div>
 		<div class="form-group-line">
-			<div class="form-group-line-xs8">
+			<div class="form-group-line-col">
+				<label id="autocomplete-framed" class="textfield mod-search">
+					<input class="textfield-input" type="search" />
+					<span class="textfield-label">Utilisateur</span>
+					<ul class="textfield-options">
+						<li class="textfield-options-entry">
+							<mark>va</mark>lue A</li>
+						<li class="textfield-options-entry is-focus">
+							<mark>va</mark>lue B</li>
+						<li class="textfield-options-entry">
+							<mark>va</mark>lue C</li>
+					</ul>
+				</label>
+			</div>
+		</div>
+		<div class="form-group-line">
+			<div class="form-group-line-col">
+				<label id="autocomplete-framed-select" class="textfield mod-select">
+					<input class="textfield-input" type="text" />
+					<span class="textfield-label">Utilisateur</span>
+					<ul class="textfield-options">
+						<li class="textfield-options-entry">
+							<mark>va</mark>lue A</li>
+						<li class="textfield-options-entry is-focus">
+							<mark>va</mark>lue B</li>
+						<li class="textfield-options-entry">
+							<mark>va</mark>lue C</li>
+					</ul>
+				</label>
+			</div>
+		</div>
+		<div class="form-group-line">
+			<div class="form-group-line-col mod-xs6">
+				<label id="autocomplete-framed-select2" class="textfield mod-select">
+					<input class="textfield-input" type="text" />
+					<span class="textfield-label">Utilisateur</span>
+					<ul class="textfield-options">
+						<li class="textfield-options-entry">
+							<mark>va</mark>lue A</li>
+						<li class="textfield-options-entry is-focus">
+							<mark>va</mark>lue B</li>
+						<li class="textfield-options-entry">
+							<mark>va</mark>lue C</li>
+					</ul>
+				</label>
+			</div>
+			<div class="form-group-line-col mod-xs6">
+				<label class="textfield is-required">
+					<input class="textfield-input is-error" type="text" placeholder="placeholder" aria-required="true" />
+					<span class="textfield-label">Label textfield</span>
+					<span class="textfield-messages">
+						<span class="textfield-messages-error">Ce champs est requis</span>
+					</span>
+				</label>
+			</div>
+		</div>
+		<div class="form-group-line">
+			<div class="form-group-line-col mod-selection">
+				<div class="checkboxesfield">
+					<label class="checkbox mod-field">
+						<input class="checkbox-input" type="checkbox" />
+						<span class="checkbox-label">Checkbox</span>
+					</label>
+				</div>
+			</div>
+		</div>
+		<div class="form-group-line">
+			<div class="form-group-line-col mod-xs8 mod-selection">
 				<fieldset class="radiosfield">
-					<legend class="form-group-line-label">Radios textfield</legend>
+					<legend class="radiosfield-label">Radios textfield</legend>
 					<div class="radiosfield-input">
 						<div>
 							<label class="radio">
-								<input class="radio-input" type="radio" name="radioframedlist">
+								<input class="radio-input" type="radio" name="radioframedlist" />
 								<span class="radio-label">Radio</span>
 							</label>
 						</div>
 						<div>
 							<label class="radio">
-								<input class="radio-input" type="radio" name="radioframedlist">
+								<input class="radio-input" type="radio" name="radioframedlist" />
 								<span class="radio-label">Radio</span>
 							</label>
 						</div>
 						<div>
 							<label class="radio">
-								<input class="radio-input" type="radio" name="radioframedlist">
+								<input class="radio-input" type="radio" name="radioframedlist" />
 								<span class="radio-label">Radio</span>
 							</label>
 						</div>
 					</div>
 				</fieldset>
 			</div>
-			<div class="form-group-line-xs4">
-				<label class="checkbox mod-field is-offset">
-					<input class="checkbox-input" type="checkbox">
-					<span class="checkbox-label">Checkbox</span>
-				</label>
+			<div class="form-group-line-col mod-selection">
+				<div class="checkboxesfield">
+					<label class="checkbox mod-field is-offset">
+						<input class="checkbox-input" type="checkbox" />
+						<span class="checkbox-label">Checkbox</span>
+					</label>
+				</div>
 			</div>
 		</div>
-	</div>
+	</fieldset>
 </div>

--- a/applications/prisme/src/app/components/form/framed/framed.feature.html
+++ b/applications/prisme/src/app/components/form/framed/framed.feature.html
@@ -1,7 +1,8 @@
 <pri-feature [infos]="infos">
 	<p class="header-description">
-		Le mode <span>Framed</span> est une mise en forme particulière des différents éléments de formulaire.<br> Dans ce mode, <code
+		Le mode <span>framed</span> est une mise en forme particulière des différents éléments de formulaire.<br> Dans ce mode, <code
 		 class="code">form-group</code> est divisé en plusieurs lignes, appelées <code class="code">form-group-line</code>.<br> Ces
-		lignes peuvent ensuite être divisées grâce aux classes <code class="code">form-group-line-*</code> (ex. <code class="code">form-group-line-xs6</code>	ou
-		<code class="code">form-group-line-lg4</code>).</p>
+		lignes sont ensuite être divisées en colonnes grâce aux classes <code class="code">form-group-line-col</code>.
+		Leurs largeurs sont alors automatiques, mais il est possible de les modifier avec des modificateurs tels
+		<code class="code">mod-xs6</code> ou <code class="code">mod-lg4</code>).</p>
 </pri-feature>

--- a/applications/prisme/src/app/components/form/framed/framed.feature.ts
+++ b/applications/prisme/src/app/components/form/framed/framed.feature.ts
@@ -18,10 +18,7 @@ export class FramedFeature {
 				code: require('!!prismjs-loader?lang=markup!./basic/basic.example.html'),
 				mod: 'white',
 				extra: `
-				Les checkboxes sont un cas particulier ici. Elles sont isolées
-				et doivent porter le mod <code class="code">mod-field</code> pour fonctionner<br>
-				En rajoutant sur la <code class="code">checkbox</code> la classe <code class="code">is-offset</code>
-				vous pouvez aligner la checkbox avec le contenu d'un input avec label
+				Les radios et checkboxes sont un cas particulier ici. Ils doivent porter le mod <code class="code">mod-selection</code> pour fonctionner et inclure une structure spécifique.
 				`
 			},
 		]

--- a/applications/prisme/src/app/components/form/textfields/styles/styles.example.html
+++ b/applications/prisme/src/app/components/form/textfields/styles/styles.example.html
@@ -1,18 +1,18 @@
 <div>
 	<label class="textfield mod-compact">
-		<input class="textfield-input" type="text" placeholder="placeholder">
+		<input class="textfield-input" type="text" placeholder="placeholder" />
 		<span class="textfield-label">Label textfield</span>
 	</label>
 </div>
 <div>
 	<label class="textfield mod-material">
-		<input class="textfield-input" type="text" placeholder="placeholder">
+		<input class="textfield-input" type="text" placeholder="placeholder" />
 		<span class="textfield-label">Label textfield</span>
 	</label>
 </div>
 <div>
 	<label class="textfield mod-framed">
-		<input class="textfield-input" type="text" placeholder="placeholder">
+		<input class="textfield-input" type="text" placeholder="placeholder" />
 		<span class="textfield-label">Label textfield</span>
 	</label>
 </div>

--- a/applications/prisme/src/app/components/form/textfields/styles/styles.example.ts
+++ b/applications/prisme/src/app/components/form/textfields/styles/styles.example.ts
@@ -2,8 +2,7 @@ import { Component } from '@angular/core';
 
 @Component({
 	selector: 'ds-styles-example',
-	templateUrl: './styles.example.html',
-	styleUrls: ['../textfields.multiple.scss']
+	templateUrl: './styles.example.html'
 })
 export class StylesExampleComponent {
 	constructor() { }

--- a/applications/prisme/src/app/components/layout/filters/basic/basic.example.html
+++ b/applications/prisme/src/app/components/layout/filters/basic/basic.example.html
@@ -2,7 +2,7 @@
 	<div class="filters-sectionLeft">
 		<div class="filters-item">
 			<label class="textfield mod-framed">
-				<input class="textfield-input" type="text" value="Tous les collaborateurs" placeholder="placeholder">
+				<input class="textfield-input" type="text" value="Tous les collaborateurs" placeholder="placeholder" />
 				<span class="textfield-label">Collaborateurs</span>
 			</label>
 		</div>
@@ -16,7 +16,7 @@
 	<div class="filters-sectionRight">
 		<div class="filters-item">
 			<label class="textfield mod-framed">
-				<input class="textfield-input" type="text" value="Tous" placeholder="placeholder">
+				<input class="textfield-input" type="text" value="Tous" placeholder="placeholder" />
 				<span class="textfield-label">Entités légales</span>
 			</label>
 		</div>

--- a/applications/prisme/src/app/components/layout/filters/sticky/sticky.example.html
+++ b/applications/prisme/src/app/components/layout/filters/sticky/sticky.example.html
@@ -2,7 +2,7 @@
 	<div class="filters-sectionLeft">
 		<div class="filters-item">
 			<label class="textfield mod-framed">
-				<input class="textfield-input" type="text" value="Tous les collaborateurs" placeholder="placeholder">
+				<input class="textfield-input" type="text" value="Tous les collaborateurs" placeholder="placeholder" />
 				<span class="textfield-label">Collaborateurs</span>
 			</label>
 		</div>
@@ -16,7 +16,7 @@
 	<div class="filters-sectionRight">
 		<div class="filters-item">
 			<label class="textfield mod-framed">
-				<input class="textfield-input" type="text" value="Tous" placeholder="placeholder">
+				<input class="textfield-input" type="text" value="Tous" placeholder="placeholder" />
 				<span class="textfield-label">Entités légales</span>
 			</label>
 		</div>


### PR DESCRIPTION
Procèdure de migration du `mod-framed`
======================================

Labels englobants
-----------------

Les labels sont passés en englobants pour :

- améliorer l’U.X. en offrant une zone cliquable plus grande pour sélectionner un champ ;
- améliorer l’accessibilité en englobants toutes les informations relatives au champs (informations connexes, remontée d’erreur) dans l’intitulé ;
- simplifier le code laissant la possibilité de ne plus utiliser le couple for/id habituel.

On passe donc de :

```
<div class="textfield">
	<input  id="id" class="textfield-input" type="text">
	<label for="id" class="textfield-label">Label textfield</label>
</div>
```

à :

```
<label class="textfield">
	<input class="textfield-input" type="text" />
	<span  class="textfield-label">Label textfield</span>
</label>
```

ou encore, avec une remontée d’erreur : 

```
<label class="textfield">
	<input class="textfield-input" type="text" />
	<span  class="textfield-label">Label textfield</span>
	<span class="textfield-messages">
		<span class="textfield-messages-error">Ce champs est requis</span>
	</span>
</label>
```

Structure en colonnes
---------------------

La structure en colonnes des champs est revue pour :

- permettre de faire des colonnes de largeurs automatiques.

On passe donc de :

```
<div class="form-group-line">
	<div class="form-group-line-lg8">
		…
	</div>
	<div class="form-group-line-lg4">
		…
	</div>
</div>
```

à :

```
<div class="form-group-line">
	<div class="form-group-line-col mod-lg8">
		…
	</div>
	<div class="form-group-line-col mod-lg4">
		…
	</div>
</div>
```

ou encore, avec des largeurs automatiques : 

```
<div class="form-group-line">
	<div class="form-group-line-col">
		…
	</div>
	<div class="form-group-line-col">
		…
	</div>
</div>
```

Regroupements de champs
-----------------------

Les champs de formulaires peuvent être regroupés :

- pour améliorer l’accessibilité et redonner à l’utilisateur le contexte d’utilisation du champ courant.

On passe donc de :

```
<div class="form-group">
	<h2>Titre Groupe 1</h2>
	…
</div>
```

à : 

```
<fieldset class="form-group">
	<legend class="form-group-legend">Titre Groupe 1</legend>
	…
</fieldset>
```

Cases à cocher et boutons radios
--------------------------------

Leurs structures sont modifiées pour :

- offrir plus de possibilités graphiques (au focus, en cas de remontée d’erreur, etc.) ;
- améliorer leur accessibilité avec un regroupement de champs.

On passe donc de :

```
<div class="checkbox mod-field">
	…
</div>
```

à :

```
<div class="form-group-line-col mod-selection">
	<div class="checkboxesfield">
		<label class="checkbox">
			…
		</label>
	</div>
</div>
```

ou encore, en cas de regroupement :

```
<div class="form-group-line-col mod-selection">
	<fieldset class="radiosfield">
		<legend class="radiosfield-label">Radios textfield</legend>
		<div>
			<label class="radio">
				…
			</label>
		</div>
		<div>
			<label class="radio">
				…
			</label>
		</div>
		<div>
			<label class="radio">
				…
			</label>
		</div>
	</fieldset >
</div>
```

Champs obligatoires
-------------------

Les champs obligatoires se voient attribuées d’un nouvel attribut :

- pour améliorer l’accessibilité et remonté leur état sémantiquement.

On passe donc de :

```
<div class="textfield is-required">
	<input id="id" class="textfield-input" type="text">
	…
</div>
```

à : 

```
<label class="textfield is-required">
	<input class="textfield-input" type="text" aria-required="true" />
	…
</label>
```






![image](https://user-images.githubusercontent.com/64789527/95099909-cd5a3d80-0730-11eb-978f-700ef81d1648.png)
