### PR TITLE
Fix icons accessibility

### DIFF
--- a/applications/prisme/src/app/components/feedback/boxes/killable/killable.example.html
+++ b/applications/prisme/src/app/components/feedback/boxes/killable/killable.example.html
@@ -1,7 +1,7 @@
 <div class="box">
 	<div class="box-close">
 		<button class="actionIcon">
-			<span aria-hidden="true" class="lucca-icon">cross</span>
+			<span aria-hidden="true" class="lucca-icon icon-cross"></span>
 		</button>
 	</div>
 	Jujubes toppin gvueoat cake cake lemon drops chupa chups sweet roll. Macaroon icing tootsie roll bonbon dragée carrot cake

--- a/applications/prisme/src/app/components/feedback/callouts/icons/icons.example.html
+++ b/applications/prisme/src/app/components/feedback/callouts/icons/icons.example.html
@@ -1,16 +1,24 @@
 <div class="callout mod-icon">
-	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">help</span></div>
+	<div class="callout-icon">
+		<span aria-hidden="true" class="lucca-icon icon-help"></span>
+	</div>
 	<strong class="callout-title">Besoin d'aide ? </strong> Je suis un callout standard
 </div>
 <div class="callout mod-icon palette-success">
-	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">tick_bold</span></div>
+	<div class="callout-icon">
+		<span aria-hidden="true" class="lucca-icon icon-tick"></span>
+	</div>
 	<strong class="callout-title">Cool!</strong> Je suis un callout de succès :)
 </div>
 <div class="callout mod-icon palette-warning">
-	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">warning</span></div>
+	<div class="callout-icon">
+		<span aria-hidden="true" class="lucca-icon icon-warning"></span>
+	</div>
 	<strong class="callout-title">Hmmm...</strong> Je suis un callout d'alarme :|
 </div>
 <div class="callout mod-icon palette-error">
-	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">error</span></div>
+	<div class="callout-icon">
+		<span aria-hidden="true" class="lucca-icon icon-error"></span>
+	</div>
 	<strong class="callout-title">Oops!</strong> Je suis un callout d'erreur :(
 </div>

--- a/applications/prisme/src/app/components/form/textfields/clear/clear.example.html
+++ b/applications/prisme/src/app/components/form/textfields/clear/clear.example.html
@@ -2,6 +2,6 @@
   <label class="textfield mod-clearable">
     <input class="textfield-input" type="text" placeholder="placeholder">
     <span class="textfield-label">Label textfield</span>
-    <a href="#" role="button" class="actionIcon textfield-actionClear"><span aria-hidden="true" class="lucca-icon">thin_cross</span></a>
+    <a href="#" role="button" class="actionIcon textfield-actionClear"><span aria-hidden="true" class="lucca-icon icon-cross"></span></a>
   </label>
 </div>

--- a/applications/prisme/src/app/components/listings/lists/basic/basic.example.html
+++ b/applications/prisme/src/app/components/listings/lists/basic/basic.example.html
@@ -5,8 +5,10 @@
 			<p class="list-item-content-description">Description</p>
 		</div>
 		<div class="list-item-actions">
-			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">edit</span></button>
-			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">trash</span></button>
+			<button class="actionIcon">
+				<span aria-hidden="true" class="lucca-icon icon-edit"></span>
+			</button>
+			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
 		</div>
 	</li>
 	<li class="list-item">
@@ -15,8 +17,12 @@
 			<p class="list-item-content-description">Description</p>
 		</div>
 		<div class="list-item-actions">
-			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">edit</span></button>
-			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">trash</span></button>
+			<button class="actionIcon">
+				<span aria-hidden="true" class="lucca-icon icon-edit"></span>
+			</button>
+			<button class="actionIcon">
+				<span aria-hidden="true" class="lucca-icon icon-trash"></span>
+			</button>
 		</div>
 	</li>
 </ul>

--- a/applications/prisme/src/app/components/listings/lists/clickable/clickable.example.html
+++ b/applications/prisme/src/app/components/listings/lists/clickable/clickable.example.html
@@ -5,8 +5,8 @@
 			<p class="list-item-content-description">Description</p>
 		</div>
 		<div class="list-item-actions">
-			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">edit</span></button>
-			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">trash</span></button>
+			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-edit"></span></button>
+			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
 		</div>
 	</li>
 	<li class="list-item mod-clickable">
@@ -15,8 +15,8 @@
 			<p class="list-item-content-description">Description</p>
 		</div>
 		<div class="list-item-actions">
-			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">edit</span></button>
-			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">trash</span></button>
+			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-edit"></span></button>
+			<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
 		</div>
 	</li>
 </ul>

--- a/applications/prisme/src/app/components/listings/tables/actions/actions.component.html
+++ b/applications/prisme/src/app/components/listings/tables/actions/actions.component.html
@@ -13,8 +13,12 @@
 			<td class="table-body-row-cell">Contenu</td>
 			<td class="table-body-row-cell">Contenu</td>
 			<td class="table-body-row-cell mod-actions">
-				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">edit</span></button>
-				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">trash</span></button>
+				<button class="actionIcon">
+					<span aria-hidden="true" class="lucca-icon icon-edit"></span>
+				</button>
+				<button class="actionIcon">
+					<span aria-hidden="true" class="lucca-icon icon-trash"></span>
+				</button>
 			</td>
 		</tr>
 		<tr class="table-body-row">
@@ -22,8 +26,8 @@
 			<td class="table-body-row-cell">Contenu</td>
 			<td class="table-body-row-cell">Contenu</td>
 			<td class="table-body-row-cell mod-actions">
-				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">edit</span></button>
-				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">trash</span></button>
+				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-edit"></span></button>
+				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
 			</td>
 		</tr>
 		<tr class="table-body-row">
@@ -31,8 +35,8 @@
 			<td class="table-body-row-cell">Contenu</td>
 			<td class="table-body-row-cell">Contenu</td>
 			<td class="table-body-row-cell mod-actions">
-				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">edit</span></button>
-				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">trash</span></button>
+				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-edit"></span></button>
+				<button class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
 			</td>
 		</tr>
 	</tbody>

--- a/applications/prisme/src/app/components/misc/functions/functions.feature.html
+++ b/applications/prisme/src/app/components/misc/functions/functions.feature.html
@@ -2,7 +2,7 @@
 
 <section class="page-content u-animatedFadeIn">
 	<div class="callout mod-icon palette-info">
-		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">info</span></div>
+		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon icon-info"></span></div>
 		Les fonctions sont accessibles en ajoutant <code class="code">@import "~@lucca-front/scss/src/theming.overridable"</code> à votre composant.<br>
 		Elles retournent des objets dont la notation est <code class="code">parent.child.[...]</code>.
 	</div>

--- a/applications/prisme/src/app/components/misc/mixins/mixins.feature.html
+++ b/applications/prisme/src/app/components/misc/mixins/mixins.feature.html
@@ -11,7 +11,7 @@
 
 <div class="callout mod-icon palette-info">
 	<div class="callout-icon">
-		<span aria-hidden="true" class="lucca-icon">info</span>
+		<span aria-hidden="true" class="lucca-icon icon-info"></span>
 	</div>
 	Il est très souvent utile d'utiliser la mixin makeIcon dans un ::before
 </div>
@@ -55,7 +55,7 @@
 </pre></code>
 <div class="callout mod-icon palette-info">
 	<div class="callout-icon">
-		<span aria-hidden="true" class="lucca-icon">info</span>
+		<span aria-hidden="true" class="lucca-icon icon-info"></span>
 	</div>
 	La classe .u-mask fait directement appel à cette mixin.
 </div>

--- a/applications/prisme/src/app/components/misc/utilities/utilities.feature.html
+++ b/applications/prisme/src/app/components/misc/utilities/utilities.feature.html
@@ -313,7 +313,7 @@
 			<code class="code">u-textError</code>
 		</p>
 		<div class="callout mod-icon palette-info">
-			<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">info</span></div>
+			<div class="callout-icon"><span aria-hidden="true" class="lucca-icon icon-info"></span></div>
 			Les couleurs de votre palette sont éditables via votre <a href="https://github.com/LuccaSA/lucca-front/#palettes" target="_blank">thème</a>
 		</div>
 	</section>

--- a/applications/prisme/src/app/components/templates/guidelines/guidelines.feature.html
+++ b/applications/prisme/src/app/components/templates/guidelines/guidelines.feature.html
@@ -66,7 +66,7 @@
 		</div>
 	</div>
 	<div class="callout mod-icon palette-info u-marginTopStandard">
-		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">info</span></div>
+		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon icon-info"></span></div>
 		Par défaut, le layout est automatiquement géré grâce aux sélecteurs de proximité entre <code class="code">.navSide</code> et <code class="code">.mainContent</code>. En cas d'impossibilité de placer ces deux composants côte à côte, il est possible d'utiliser les classes <code class="code">.mod-withMenu</code> et <code class="code">.mod-withMenuCompact</code> sur un parent de <code class="code">.main-content</code> pour lui donner la bonne mise en forme.
 	</div>
 </section>

--- a/applications/prisme/src/app/home/home-splash/home-splash.component.html
+++ b/applications/prisme/src/app/home/home-splash/home-splash.component.html
@@ -15,7 +15,7 @@
 		<div class="grid-lg4">
 			<a routerLink="/principles" class="card mod-clickable mod-principles">
 				<div class="card-content">
-					<div class="splash-card-icon"><span aria-hidden="true" class="lucca-icon">heart</span></div>
+					<div class="splash-card-icon"><span aria-hidden="true" class="lucca-icon icon-heart"></span></div>
 					<h3>Principes</h3>
 					<div class="u-textLight u-textSmall">Découvrez les lignes directrices de notre vision du design chez Lucca.</div>
 				</div>
@@ -24,7 +24,7 @@
 		<div class="grid-lg4">
 			<a routerLink="/identity" class="card mod-clickable mod-identity">
 				<div class="card-content">
-					<div class="splash-card-icon"><span aria-hidden="true" class="lucca-icon">palette</span></div>
+					<div class="splash-card-icon"><span aria-hidden="true" class="lucca-icon icon-palette"></span></div>
 					<h3>Identité graphique</h3>
 					<div class="u-textLight u-textSmall">Comprenez les éléments de notre charte et apprenez à communiquer par l'image.</div>
 				</div>
@@ -33,7 +33,7 @@
 		<div class="grid-lg4">
 			<a routerLink="/components" class="card mod-clickable mod-components">
 				<div class="card-content">
-					<div class="splash-card-icon"><span aria-hidden="true" class="lucca-icon">puzzle</span></div>
+					<div class="splash-card-icon"><span aria-hidden="true" class="lucca-icon icon-puzzle"></span></div>
 					<h3>Composants</h3>
 					<div class="u-textLight u-textSmall">Parcourez nos composants SASS et Angular et apprenez à les utiliser dans vos applications.</div>
 				</div>

--- a/applications/prisme/src/guidelines/principles/content/typographic-rules/typographic-rules.guidelines.md
+++ b/applications/prisme/src/guidelines/principles/content/typographic-rules/typographic-rules.guidelines.md
@@ -17,7 +17,7 @@
 </div>
 
 <div class="callout mod-icon palette-info">
-	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">info</span></div>
+	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon icon-info"></span></div>
 	En anglais, ces signes de ponctuation ne sont pas précédés d’un espace.
 </div>
 
@@ -57,7 +57,7 @@ L'apostrophe droite, ou apostrophe dactylographique, ne doit pas être utilisée
 </div>
 
 <div class="callout mod-icon palette-info">
-	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">info</span></div>
+	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon icon-info"></span></div>
 	<strong class="callout-title">Raccourci Windows</strong> alt + 0146<br>
 	<strong class="callout-title">Raccourci Mac</strong> option + shift + ‘
 </div>
@@ -100,7 +100,7 @@ Dans tous les cas, un texte dont la lecture complète est importante à la compr
 </div>
 
 <div class="callout mod-icon palette-info">
-	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">info</span></div>
+	<div class="callout-icon"><span aria-hidden="true" class="lucca-icon icon-info"></span></div>
 	En anglais, les milliers, millions, etc. sont séparés d’une virgule et les nombres décimaux sont séparés d’un point.
 </div>
 

--- a/libraries/common/src/lib/feature/example/examples.component.html
+++ b/libraries/common/src/lib/feature/example/examples.component.html
@@ -4,7 +4,7 @@
 	<pri-code-tabs [example]="selectedExample"></pri-code-tabs>
 	<div class="callout mod-icon palette-info" *ngIf="selectedExample.extra != null">
 		<div class="callout-icon">
-			<span aria-hidden="true" class="lucca-icon">info</span>
+			<span aria-hidden="true" class="lucca-icon icon-info"></span>
 		</div>
 		<span class="extra-infos" [innerHtml]="selectedExample.extra | priSafeContent: 'html'"></span>
 	</div>

--- a/libraries/common/src/lib/markdown/markdown.options.ts
+++ b/libraries/common/src/lib/markdown/markdown.options.ts
@@ -9,7 +9,7 @@ export class MarkedOptions extends NgxMarkedOptions {
 			return `
 			<div class="callout mod-icon palette-info">
 				<div class="callout-icon">
-					<span aria-hidden="true" class="lucca-icon">info</span>
+					<span aria-hidden="true" class="lucca-icon icon-info"></span>
 				</div>
 				<span class="extra-infos">${text}</span>
 			</div>`;


### PR DESCRIPTION
Correction de l'accessibilité de tous les exemples qui utilisent des icônes

```html
<span aria-hidden="true" class="lucca-icon">edit</span>
```
devient
```html
<span aria-hidden="true class="lucca-icon icon-edit"></span>
```